### PR TITLE
Update workflow actions version

### DIFF
--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -12,19 +12,19 @@ runs:
       dotnet-version: '8.0.x'
 
   - name: Install GitVersion
-    uses: gittools/actions/gitversion/setup@v3.1.11
+    uses: gittools/actions/gitversion/setup@v4.0.0
     with:
-      versionSpec: '6.0.x'
+      versionSpec: '6.3.x'
 
   - name: Determine Version
     id: gitversion
-    uses: gittools/actions/gitversion/execute@v3.1.11
+    uses: gittools/actions/gitversion/execute@v4.0.0
     with:
-      useConfigFile: true
+      configFilePath: GitVersion.yml
 
   - name: Setup assets cache
     id: assetscache
-    uses: actions/cache@v3
+    uses: actions/cache@v4
     with:
       path: output/RequiredModules
       key: ${{ hashFiles('RequiredModules.psd1') }}

--- a/.github/actions/code-coverage/action.yml
+++ b/.github/actions/code-coverage/action.yml
@@ -8,7 +8,6 @@ runs:
   steps:
   - uses: actions/checkout@v4
     with:
-      ref: ${{ github.head_ref }}
       fetch-depth: 0
 
   - name: Download Test Artifact Linux

--- a/.github/actions/run-tests/action.yml
+++ b/.github/actions/run-tests/action.yml
@@ -8,7 +8,6 @@ runs:
   steps:
   - uses: actions/checkout@v4
     with:
-      ref: ${{ github.head_ref }}
       fetch-depth: 0
 
   - name: Download Build Artifact

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,7 +45,6 @@ jobs:
     - name: Checkout Code
       uses: actions/checkout@v4
       with:
-        ref: ${{ github.head_ref }}
         fetch-depth: 0
     - name: 'Test on Linux'
       uses: ./.github/actions/run-tests
@@ -59,7 +58,6 @@ jobs:
     - name: Checkout Code
       uses: actions/checkout@v4
       with:
-        ref: ${{ github.head_ref }}
         fetch-depth: 0
     - name: 'Test on Windows'
       uses: ./.github/actions/run-tests
@@ -76,7 +74,6 @@ jobs:
     - name: Checkout Code
       uses: actions/checkout@v4
       with:
-        ref: ${{ github.head_ref }}
         fetch-depth: 0
     - name: 'Publish Code Coverage'
       uses: ./.github/actions/code-coverage
@@ -87,12 +84,15 @@ jobs:
     needs:
     - build
     - test-linux
+    - test-win
     - code-coverage
+    permissions:
+      contents: write
+      pull-requests: write
     steps:
     - name: Checkout Code
       uses: actions/checkout@v4
       with:
-        ref: ${{ github.head_ref }}
         fetch-depth: 0
     
     - name: Download Build Artifact
@@ -110,6 +110,6 @@ jobs:
 
     - name: Send Changelog PR
       shell: pwsh
-      run: Get-Module -Name PowerShellForGitHub -ListAvailable ;./build.ps1  -tasks Create_ChangeLog_GitHub_PR
+      run: ./build.ps1 -tasks Create_ChangeLog_GitHub_PR
       env:
         GitHubToken: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,7 +31,6 @@ jobs:
     - name: Checkout Code
       uses: actions/checkout@v4
       with:
-        ref: ${{ github.head_ref }}
         fetch-depth: 0
 
     - name: 'Build and Package Module'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Added automation for generating the changelog and release notes
+
 ### Changed 
 - Updated dependency on AzAuth to version 2.5.0
 

--- a/build.yaml
+++ b/build.yaml
@@ -133,8 +133,6 @@ TaskHeader: |
 GitHubConfig:
   GitHubFilesToAdd:
     - 'CHANGELOG.md'
-  ReleaseAssets:
-    - output/WikiContent.zip
   GitHubConfigUserName: SimonWahlin
   GitHubConfigUserEmail: 5576847+SimonWahlin@users.noreply.github.com
   UpdateChangelogOnPrerelease: false

--- a/build.yaml
+++ b/build.yaml
@@ -130,8 +130,11 @@ TaskHeader: |
   Write-Build DarkGray "  $($Task.InvocationInfo.ScriptName):$($Task.InvocationInfo.ScriptLineNumber)"
   ""
 
-
-
-
-
-
+GitHubConfig:
+  GitHubFilesToAdd:
+    - 'CHANGELOG.md'
+  ReleaseAssets:
+    - output/WikiContent.zip
+  GitHubConfigUserName: SimonWahlin
+  GitHubConfigUserEmail: 5576847+SimonWahlin@users.noreply.github.com
+  UpdateChangelogOnPrerelease: false


### PR DESCRIPTION
Update gitversion and cache actions to latest version

Also removed ref: property of checkout, the way we use it is the same as the default and this way it is compatible with act.